### PR TITLE
Fix dangled Link in README

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,12 +10,12 @@ dependencies:
 
 documentation:
   - docs/**/*
-  - README.adoc
+  - README.md
   - LICENSE
-  - CHANGELOG.adoc
-  - CODE-OF-CONDUCT.adoc
-  - CONTRIBUTION.adoc
-  - readmeOSS.adoc
+  - CHANGELOG.md
+  - CODE-OF-CONDUCT.md
+  - CONTRIBUTION.md
+  - SECURITY.md
 
 # Library
 test-utils:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KFixture
+# Test Utils
 A tool to generate randomized test values for Kotlin Multiplatform.
 
 [![Latest release](https://raw.githubusercontent.com/bitPogo/test-utils-kmp/main/docs/src/assets/badge-release-latest.svg)](https://github.com/bitPogo/kfixture/releases)
@@ -15,7 +15,7 @@ Coming soon
 
 ## Changelog
 
-See [changelog](https://github.com/bitPogo/kfixture/blob/main/CHANGELOG.md).
+See [changelog](https://github.com/bitPogo/test-utils-kmp/blob/main/CHANGELOG.md).
 
 ## Versioning
 


### PR DESCRIPTION
This just fixes a dangled link in the README and adjusts the labler.